### PR TITLE
Improve login flow and capture countdown experience

### DIFF
--- a/src/app/capture/[uuid]/page.tsx
+++ b/src/app/capture/[uuid]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useContext, useEffect, useState } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { GameContext } from '@/context/GameContext';
 import { Loader2, CheckCircle, XCircle } from 'lucide-react';
@@ -8,62 +8,72 @@ import ClientOnly from '@/components/client-only';
 
 type CaptureStatus = 'counting' | 'capturing' | 'success' | 'failure' | 'invalid';
 
+const COUNTDOWN_DURATION = 10_000;
+
 export default function CapturePage({ params }: { params: { uuid: string } }) {
   const router = useRouter();
   const context = useContext(GameContext);
-  const [countdown, setCountdown] = useState(10);
+  const [timeLeft, setTimeLeft] = useState(10);
+  const [progress, setProgress] = useState(0);
   const [status, setStatus] = useState<CaptureStatus>('counting');
-  
+  const captureTriggeredRef = useRef(false);
+
   const { player, game, captureZone, loading } = context || {};
-  
-  // Extract the last character from the UUID to get the zone identifier
+
   const zoneLetter = params.uuid.slice(-1);
   const zoneId = `zone-${zoneLetter}`;
 
-  useEffect(() => {
-    if (!loading && !player) {
-      router.push('/login');
-      return;
+  const playerTeamId = useMemo(() => {
+    if (!player || !game) return null;
+    if (game.teams.splatSquad.players.some((p) => p.id === player.id)) {
+      return 'splatSquad' as const;
     }
+    if (game.teams.inkMasters.players.some((p) => p.id === player.id)) {
+      return 'inkMasters' as const;
+    }
+    return null;
+  }, [game, player]);
 
-    if (!loading && player && game) {
-      const isPlayerInTeam = game.teams.splatSquad.players.some(p => p.id === player.id) || game.teams.inkMasters.players.some(p => p.id === player.id);
-      if (!isPlayerInTeam) {
-        router.push('/setup');
-        return;
-      }
+  const teamColor = useMemo(() => {
+    if (!game || !playerTeamId) {
+      return 'hsl(var(--primary))';
     }
-    
-    if (!loading && game && game.status !== 'playing') {
+    return game.teams[playerTeamId].color;
+  }, [game, playerTeamId]);
+
+  useEffect(() => {
+    if (loading) return;
+    if (!player) {
+      router.replace('/manual-login');
+    }
+  }, [loading, player, router]);
+
+  useEffect(() => {
+    if (loading || !player || !game) return;
+    if (!playerTeamId) {
+      router.replace('/setup');
+    }
+  }, [loading, player, game, playerTeamId, router]);
+
+  useEffect(() => {
+    if (loading || !game) return;
+    if (game.status !== 'playing') {
       setStatus('failure');
+      const timeout = setTimeout(() => router.push('/game'), 3000);
+      return () => clearTimeout(timeout);
+    }
+  }, [loading, game, router]);
+
+  const handleCapture = useCallback(async () => {
+    if (!captureZone || !game) return;
+
+    const zone = game.zones.find((z) => z.id === zoneId);
+    if (!zone) {
+      setStatus('invalid');
       setTimeout(() => router.push('/game'), 3000);
       return;
     }
 
-    if(status === 'counting' && !loading && game && game.status === 'playing'){
-        const interval = setInterval(() => {
-            setCountdown(prev => prev - 1);
-        }, 1000);
-    
-        if (countdown <= 0) {
-          clearInterval(interval);
-          setStatus('capturing');
-          handleCapture();
-        }
-        return () => clearInterval(interval);
-    }
-  }, [countdown, player, game, loading, router, status]);
-
-  const handleCapture = async () => {
-    if (!captureZone || !game) return;
-
-    const zone = game.zones.find(z => z.id === zoneId);
-    if (!zone) {
-        setStatus('invalid');
-        setTimeout(() => router.push('/game'), 3000);
-        return;
-    }
-    
     try {
       await captureZone(zoneId);
       setStatus('success');
@@ -72,47 +82,87 @@ export default function CapturePage({ params }: { params: { uuid: string } }) {
     } finally {
       setTimeout(() => router.push('/game'), 3000);
     }
-  };
+  }, [captureZone, game, router, zoneId]);
+
+  useEffect(() => {
+    if (status !== 'counting' || loading || !game || game.status !== 'playing') {
+      return;
+    }
+
+    captureTriggeredRef.current = false;
+    setTimeLeft(10);
+    setProgress(0);
+
+    const start = performance.now();
+    let animationFrame: number;
+
+    const updateTimer = (now: number) => {
+      const elapsed = now - start;
+      const remaining = Math.max(0, COUNTDOWN_DURATION - elapsed);
+
+      setTimeLeft(Math.max(0, Math.ceil(remaining / 1000)));
+      setProgress(Math.min(1, elapsed / COUNTDOWN_DURATION));
+
+      if (remaining <= 0) {
+        if (!captureTriggeredRef.current) {
+          captureTriggeredRef.current = true;
+          setStatus('capturing');
+          handleCapture();
+        }
+        return;
+      }
+
+      animationFrame = requestAnimationFrame(updateTimer);
+    };
+
+    animationFrame = requestAnimationFrame(updateTimer);
+
+    return () => {
+      if (animationFrame) {
+        cancelAnimationFrame(animationFrame);
+      }
+    };
+  }, [status, loading, game, handleCapture]);
 
   const renderStatus = () => {
     switch (status) {
-      case 'counting':
+      case 'counting': {
+        const zoneLabel = zoneId.split('-')[1]?.toUpperCase();
+        const rotation = -90;
         return (
           <>
-            <div className="relative flex items-center justify-center">
-              <svg className="w-48 h-48 transform -rotate-90">
-                <circle className="text-secondary" strokeWidth="20" stroke="currentColor" fill="transparent" r="72" cx="96" cy="96" />
-                <circle
-                  className="text-primary"
-                  strokeWidth="20"
-                  strokeDasharray={2 * Math.PI * 72}
-                  strokeDashoffset={2 * Math.PI * 72 * (1 - countdown / 10)}
-                  strokeLinecap="round"
-                  stroke="currentColor"
-                  fill="transparent"
-                  r="72"
-                  cx="96"
-                  cy="96"
-                />
-              </svg>
-              <span className="absolute text-6xl font-black">{countdown}</span>
+            <div className="relative flex h-48 w-48 items-center justify-center">
+              <div
+                className="absolute inset-0 rounded-full"
+                style={{
+                  background: `conic-gradient(${teamColor} ${progress * 360}deg, rgba(255,255,255,0.1) ${progress * 360}deg)`,
+                  transform: `rotate(${rotation}deg)`,
+                  transition: 'background 0.1s linear',
+                  boxShadow: `0 0 25px -5px ${teamColor}`,
+                }}
+              />
+              <div className="absolute inset-3 rounded-full bg-background/90 backdrop-blur-sm shadow-inner shadow-black/30" />
+              <span className="relative text-6xl font-black drop-shadow-lg">{timeLeft}</span>
             </div>
-            <h1 className="text-3xl font-bold mt-4">Capturando Zona {zoneId.split('-')[1].toUpperCase()}...</h1>
-            <p className="text-muted-foreground">Mantenha sua posição!</p>
+            <h1 className="mt-6 text-3xl font-bold" style={{ color: teamColor }}>
+              Capturando Zona {zoneLabel}...
+            </h1>
+            <p className="text-muted-foreground">Mantenha a mira no QR Code até o fim!</p>
           </>
         );
+      }
       case 'capturing':
         return (
           <>
             <Loader2 className="h-24 w-24 animate-spin text-primary" />
-            <h1 className="text-3xl font-bold mt-4">Processando Captura...</h1>
+            <h1 className="mt-4 text-3xl font-bold">Processando Captura...</h1>
           </>
         );
       case 'success':
         return (
           <>
             <CheckCircle className="h-24 w-24 text-green-500" />
-            <h1 className="text-3xl font-bold mt-4 text-green-400">Zona Capturada!</h1>
+            <h1 className="mt-4 text-3xl font-bold text-green-400">Zona Capturada!</h1>
             <p className="text-muted-foreground">Redirecionando de volta para o jogo...</p>
           </>
         );
@@ -121,11 +171,13 @@ export default function CapturePage({ params }: { params: { uuid: string } }) {
         return (
           <>
             <XCircle className="h-24 w-24 text-red-500" />
-            <h1 className="text-3xl font-bold mt-4 text-red-400">
-                {status === 'invalid' ? 'QR Code Inválido' : 'Captura Falhou!'}
+            <h1 className="mt-4 text-3xl font-bold text-red-400">
+              {status === 'invalid' ? 'QR Code Inválido' : 'Captura Falhou!'}
             </h1>
             <p className="text-muted-foreground">
-                {game?.status !== 'playing' ? 'O jogo não está ativo no momento.' : 'Redirecionando de volta para o jogo...'}
+              {game?.status !== 'playing'
+                ? 'O jogo não está ativo no momento.'
+                : 'Redirecionando de volta para o jogo...'}
             </p>
           </>
         );
@@ -134,7 +186,7 @@ export default function CapturePage({ params }: { params: { uuid: string } }) {
 
   return (
     <ClientOnly>
-      <div className="flex min-h-screen flex-col items-center justify-center text-center p-4 animate-in fade-in">
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-4 text-center animate-in fade-in">
         {renderStatus()}
       </div>
     </ClientOnly>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useContext, useEffect, useMemo } from 'react';
+import { useContext, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { GameContext } from '@/context/GameContext';
 import { Loader2, PaintRoller } from 'lucide-react';
@@ -29,16 +29,18 @@ export default function LoginPage() {
   const { player, login } = context || {};
 
   useEffect(() => {
-    if (context?.loading) {
+    if (context?.loading || !login) {
       return;
     }
 
     if (player) {
       router.push('/setup');
-    } else if (login) {
-      const { name, emoji } = generateRandomPlayer();
-      login(name, emoji);
+      return;
     }
+
+    const { name, emoji } = generateRandomPlayer();
+    login(name, emoji);
+    router.push('/setup');
   }, [player, login, router, context?.loading]);
 
   return (

--- a/src/components/login/LoginForm.tsx
+++ b/src/components/login/LoginForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useContext } from 'react';
+import { useRouter } from 'next/navigation';
 import { GameContext } from '@/context/GameContext';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -12,12 +13,16 @@ import { PaintRoller } from 'lucide-react';
 export function LoginForm() {
   const [name, setName] = useState('');
   const [emoji, setEmoji] = useState('🦑');
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const context = useContext(GameContext);
+  const router = useRouter();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (name.trim() && context) {
+      setIsSubmitting(true);
       context.login(name.trim(), emoji);
+      router.push('/setup');
     }
   };
 
@@ -49,7 +54,11 @@ export function LoginForm() {
           </div>
         </CardContent>
         <CardFooter>
-          <Button type="submit" className="w-full h-14 text-xl font-bold transform hover:scale-105 transition-transform" disabled={!name.trim()}>
+          <Button
+            type="submit"
+            className="w-full h-14 text-xl font-bold transform hover:scale-105 transition-transform"
+            disabled={!name.trim() || isSubmitting}
+          >
             Entrar na Batalha!
           </Button>
         </CardFooter>

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -56,7 +56,7 @@ interface GameContextType {
   player: Player | null;
   game: Game | null;
   loading: boolean;
-  login: (name: string, emoji: string) => void;
+  login: (name: string, emoji: string) => Player;
   logout: () => void;
   joinTeam: (teamId: TeamId) => Promise<void>;
   selectColor: (teamId: TeamId, color: string) => Promise<void>;
@@ -131,6 +131,7 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
     const newPlayer: Player = { id: uuidv4(), name, emoji };
     setPlayer(newPlayer);
     toast({ title: `Bem-vindo, ${name}!`, description: 'Prepare-se para a batalha!' });
+    return newPlayer;
   };
 
   const logout = () => {


### PR DESCRIPTION
## Summary
- return the created player from the game context login helper and send players directly to the team setup screen after either quick or manual login
- refresh the capture countdown to a 10-second, team-colored spinner with guards that redirect unprepared players to the correct screens

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68ccf1ed9cb483309366034a7b53321a