### PR TITLE
Restrict lobby access during active games

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,21 +13,33 @@ export default function RedirectPage() {
       return; // Aguarda o carregamento do contexto
     }
 
-    if (!context?.player) {
+    const player = context?.player;
+    const game = context?.game;
+
+    if (!player) {
       router.replace('/manual-login');
       return;
     }
 
-    if (context?.game) {
-      if (context.game.status === 'playing' || context.game.status === 'finished') {
-        router.replace('/game');
-      } else { // 'setup'
-        router.replace('/setup');
-      }
-    } else {
-        // Se não houver jogo, mas houver jogador, vai para o setup
-        router.replace('/setup');
+    if (!game) {
+      router.replace('/setup');
+      return;
     }
+
+    if (game.status === 'finished') {
+      router.replace('/game');
+      return;
+    }
+
+    if (game.status === 'playing') {
+      const isPlayerInTeam = game.teams.splatSquad.players.some(p => p.id === player.id)
+        || game.teams.inkMasters.players.some(p => p.id === player.id);
+      router.replace(isPlayerInTeam ? '/game' : '/setup');
+      return;
+    }
+
+    // status === 'setup'
+    router.replace('/setup');
 
   }, [context, router]);
 

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -9,11 +9,17 @@ import { TeamCard } from '@/components/setup/TeamCard';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 
 export default function SetupPage() {
   const router = useRouter();
   const context = useContext(GameContext);
   const { game, player, voteToStart, toggleReady } = context || {};
+
+  const playerIsInTeam = useMemo(() => {
+    if (!game || !player) return false;
+    return game.teams.splatSquad.players.some(p => p.id === player.id) || game.teams.inkMasters.players.some(p => p.id === player.id);
+  }, [game, player]);
 
   useEffect(() => {
     if (context?.loading) return;
@@ -21,15 +27,17 @@ export default function SetupPage() {
         router.push('/');
         return;
     };
-    if (game && (game.status === 'playing' || game.status === 'finished')) {
+    if (!game) return;
+
+    if (game.status === 'finished') {
+      router.push('/game');
+      return;
+    }
+
+    if (game.status === 'playing' && playerIsInTeam) {
       router.push('/game');
     }
-  }, [player, game, router, context]);
-
-  const playerIsInTeam = useMemo(() => {
-    if (!game || !player) return false;
-    return game.teams.splatSquad.players.some(p => p.id === player.id) || game.teams.inkMasters.players.some(p => p.id === player.id);
-  }, [game, player]);
+  }, [player, game, router, context, playerIsInTeam]);
 
   const playerHasVoted = useMemo(() => {
     if (!game || !player) return false;
@@ -60,8 +68,22 @@ export default function SetupPage() {
       <div className="container mx-auto min-h-screen p-4 md:p-8 animate-in fade-in duration-500">
         <header className="text-center mb-8">
           <h1 className="text-5xl font-bold tracking-tighter text-primary">Configuração do Jogo</h1>
-          <p className="text-xl text-muted-foreground mt-2">Monte suas equipes e prepare-se para a batalha!</p>
+          <p className="text-xl text-muted-foreground mt-2">
+            {game.status === 'setup'
+              ? 'Monte suas equipes e prepare-se para a batalha!'
+              : 'Uma partida está em andamento. Você pode acompanhar o lobby como espectador.'}
+          </p>
         </header>
+
+        {game.status === 'playing' && !playerIsInTeam && (
+          <Alert className="mb-8 border-primary/50 bg-primary/10">
+            <Gamepad2 className="h-5 w-5" />
+            <AlertTitle>Partida em andamento</AlertTitle>
+            <AlertDescription>
+              Você está como espectador enquanto a partida atual acontece. Aguarde o término do jogo para entrar em uma equipe ou sinalizar que está pronto.
+            </AlertDescription>
+          </Alert>
+        )}
 
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
           <TeamCard teamId="splatSquad" />
@@ -76,24 +98,28 @@ export default function SetupPage() {
                 Duração do Jogo
               </CardTitle>
               <CardDescription>
-                {isPlayerReady ? "Você já está pronto e não pode mais votar." : "Vote na duração da partida. A mais votada vence!"}
+                {game.status !== 'setup'
+                  ? 'Votações indisponíveis durante uma partida em andamento.'
+                  : isPlayerReady
+                  ? "Você já está pronto e não pode mais votar."
+                  : "Vote na duração da partida. A mais votada vence!"}
               </CardDescription>
             </CardHeader>
             <CardContent className="flex flex-col sm:flex-row gap-4">
-              <Button 
-                className="w-full h-16 text-2xl transition-transform hover:scale-105" 
-                onClick={() => voteToStart?.(15)} 
-                disabled={playerHasVoted || isPlayerReady}
+              <Button
+                className="w-full h-16 text-2xl transition-transform hover:scale-105"
+                onClick={() => voteToStart?.(15)}
+                disabled={playerHasVoted || isPlayerReady || game.status !== 'setup'}
               >
                 15 Minutos
                 <div className="ml-2 flex items-center text-sm bg-background/50 rounded-full px-2 py-1">
                   <Users className="h-4 w-4 mr-1"/> {game.votes[15].length}
                 </div>
               </Button>
-              <Button 
+              <Button
                 className="w-full h-16 text-2xl transition-transform hover:scale-105"
                 onClick={() => voteToStart?.(30)}
-                disabled={playerHasVoted || isPlayerReady}
+                disabled={playerHasVoted || isPlayerReady || game.status !== 'setup'}
               >
                 30 Minutos
                  <div className="ml-2 flex items-center text-sm bg-background/50 rounded-full px-2 py-1">
@@ -110,14 +136,16 @@ export default function SetupPage() {
                     Pronto para Jogar?
                 </CardTitle>
                 <CardDescription>
-                    Quando todos os jogadores estiverem prontos, o jogo começará!
+                    {game.status === 'setup'
+                      ? 'Quando todos os jogadores estiverem prontos, o jogo começará!'
+                      : 'O lobby está bloqueado até o final da partida atual.'}
                 </CardDescription>
             </CardHeader>
             <CardContent className="flex flex-col gap-4">
-                <Button 
+                <Button
                     className={cn("w-full h-16 text-2xl transition-transform hover:scale-105", isPlayerReady && "bg-green-600 hover:bg-green-700")}
                     onClick={() => toggleReady?.()}
-                    disabled={!playerIsInTeam}
+                    disabled={!playerIsInTeam || game.status !== 'setup'}
                 >
                     <CheckCircle className="mr-2 h-8 w-8" />
                     {isPlayerReady ? "Pronto!" : "Estou Pronto"}

--- a/src/components/setup/ColorPicker.tsx
+++ b/src/components/setup/ColorPicker.tsx
@@ -30,13 +30,14 @@ export function ColorPicker({ teamId }: ColorPickerProps) {
   const otherTeamId = teamId === 'splatSquad' ? 'inkMasters' : 'splatSquad';
   const otherTeamColor = game.teams[otherTeamId].color;
   const isPlayerReady = player ? game.readyPlayers.includes(player.id) : false;
+  const lobbyLocked = game.status !== 'setup';
 
 
   return (
     <div className="grid grid-cols-8 gap-2">
       {TEAM_COLORS.map(color => {
         const isSelected = team.color === color;
-        const isDisabled = otherTeamColor === color || isPlayerReady;
+        const isDisabled = otherTeamColor === color || isPlayerReady || lobbyLocked;
         return (
           <button
             key={color}

--- a/src/components/setup/TeamCard.tsx
+++ b/src/components/setup/TeamCard.tsx
@@ -24,6 +24,14 @@ export function TeamCard({ teamId }: TeamCardProps) {
   const team = game.teams[teamId];
   const isPlayerOnThisTeam = team.players.some(p => p.id === player.id);
   const isPlayerReady = game.readyPlayers.includes(player.id);
+  const lobbyLocked = game.status !== 'setup';
+  const gameInProgress = game.status === 'playing';
+  const joinDisabled = isPlayerOnThisTeam || isPlayerReady || lobbyLocked;
+  const joinLabel = isPlayerOnThisTeam
+    ? 'Você está nesta Equipe'
+    : lobbyLocked
+    ? gameInProgress ? 'Jogo em andamento' : 'Aguardando reinício'
+    : 'Juntar-se à Equipe';
 
   return (
     <Card className="flex flex-col animate-bounce-in">
@@ -32,7 +40,13 @@ export function TeamCard({ teamId }: TeamCardProps) {
           <div className="w-4 h-8 rounded-full" style={{ backgroundColor: team.color }} />
           {team.name}
         </CardTitle>
-        <CardDescription>Selecione a cor da sua equipe e veja quem já entrou.</CardDescription>
+        <CardDescription>
+          {lobbyLocked
+            ? gameInProgress
+              ? 'Uma partida está em andamento. Aguarde para entrar após o término.'
+              : 'A última partida terminou. Aguarde o reinício para entrar.'
+            : 'Selecione a cor da sua equipe e veja quem já entrou.'}
+        </CardDescription>
       </CardHeader>
       <CardContent className="flex-grow space-y-4">
         <div>
@@ -68,13 +82,13 @@ export function TeamCard({ teamId }: TeamCardProps) {
         <Button
           className="w-full h-12 text-lg transition-transform hover:scale-105"
           onClick={() => joinTeam?.(teamId)}
-          disabled={isPlayerOnThisTeam || isPlayerReady}
+          disabled={joinDisabled}
           style={{
             backgroundColor: isPlayerOnThisTeam ? team.color : undefined,
             color: isPlayerOnThisTeam ? 'black' : undefined,
           }}
         >
-          {isPlayerOnThisTeam ? "Você está nesta Equipe" : 'Juntar-se à Equipe'}
+          {joinLabel}
         </Button>
       </div>
     </Card>

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -139,6 +139,15 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
   
   const joinTeam = async (teamId: TeamId) => {
     if (!player || !game) return;
+
+    if (game.status !== 'setup') {
+      toast({
+        variant: 'destructive',
+        title: 'Jogo em andamento',
+        description: 'Não é possível trocar de equipe durante uma partida ativa.'
+      });
+      return;
+    }
   
     const otherTeamId: TeamId = teamId === 'splatSquad' ? 'inkMasters' : 'splatSquad';
     const isPlayerInOtherTeam = game.teams[otherTeamId].players.some(p => p.id === player.id);
@@ -180,6 +189,15 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
 
   const selectColor = async (teamId: TeamId, color: string) => {
     if (!game || !player) return;
+
+    if (game.status !== 'setup') {
+      toast({
+        variant: 'destructive',
+        title: 'Jogo em andamento',
+        description: 'A cor da equipe só pode ser alterada antes da partida começar.'
+      });
+      return;
+    }
 
     if (game.readyPlayers.includes(player.id)) {
         toast({ variant: 'destructive', title: "Você já está pronto!", description: "Não é possível trocar a cor."});
@@ -231,6 +249,15 @@ export const GameProvider = ({ children }: { children: ReactNode }) => {
 
   const toggleReady = async () => {
     if (!player || !game) return;
+
+    if (game.status !== 'setup') {
+      toast({
+        variant: 'destructive',
+        title: 'Jogo em andamento',
+        description: 'O status de pronto só pode ser alterado no lobby.'
+      });
+      return;
+    }
 
     const isReady = game.readyPlayers.includes(player.id);
 


### PR DESCRIPTION
## Summary
- prevent team changes, color swaps, and readiness toggles while a match is active or finished and surface clear feedback
- keep spectators in the lobby with contextual messaging while redirecting active participants to the running match
- adjust setup UI states to disable voting and readiness actions once the lobby is locked

## Testing
- npm run typecheck
- npm run lint *(fails to run without initializing ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ccf28d92288330b57b8bf0135bafb8